### PR TITLE
code to prevent alt-keybinds

### DIFF
--- a/jsdos/index.html
+++ b/jsdos/index.html
@@ -25,6 +25,16 @@
 <body>
   <canvas id="jsdos"></canvas>
   <script>
+    
+    //prevent alt left/right keybinds in chrome from triggering back/forward action in top left
+    window.addEventListener("keydown",(e)=>{
+      const {key, keyCode, metaKey, shiftKey, altKey, ctrlKey} = e; 
+      if(key && altKey){
+        e.preventDefault();
+        console.log("alt prevented");
+      }
+    });
+    
     Dos(document.getElementById("jsdos"), {
       wdosboxUrl: "/wdosbox.js",
       cycles: 750,


### PR DESCRIPTION
When playing doom, I found it annoying that whenever I tried to strafe (alt + left/right) chrome would trigger the "go back" event. This code should prevent this from happening.